### PR TITLE
Fix typo in code sample

### DIFF
--- a/ask-sdk-mvc/README.md
+++ b/ask-sdk-mvc/README.md
@@ -179,7 +179,7 @@ A `SkillModule` groups the business logic of controllers and views with the requ
 public class HelloWorldModule implements SkillModule {
     @Override
     public void buildMvc(MvcSdkModule.Builder mvcBuilder) {
-        mvcBuilder.addController(new HelloWorldContoller());
+        mvcBuilder.addController(new HelloWorldController());
     }
 
     @Override


### PR DESCRIPTION
Just noticed a small typo when copy-pasting some code samples.


## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

[issues]: https://github.com/alexa/ask-sdk-frameworks-java/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement

